### PR TITLE
Don't recheck nodes during the pop traversal

### DIFF
--- a/.changes/unreleased/Fixed-20230707-054344.yaml
+++ b/.changes/unreleased/Fixed-20230707-054344.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Don't recheck already-checked nodes during the traversal.
+time: 2023-07-07T05:43:44.784286639-07:00

--- a/analyzer.go
+++ b/analyzer.go
@@ -73,6 +73,10 @@ var _filter = []ast.Node{
 
 func (a *analyzer) Run(inspect *inspector.Inspector) {
 	inspect.Nodes(_filter, func(n ast.Node, push bool) (proceed bool) {
+		if !push {
+			return false
+		}
+
 		switch n := n.(type) {
 		case *ast.FuncDecl:
 			// A function can't define a global variable.


### PR DESCRIPTION
inspector.Nodes calls the function twice:
once during the downward DFS and once again
when all children of a node have been visited.

We don't need to do any extra work on the way out,
so just return false early.

This doesn't actually cause any issues but it's a little wasted work.
