### PR TITLE
Degrade gracefully if 'error' is unavailable

### DIFF
--- a/.changes/unreleased/Fixed-20230708-145543.yaml
+++ b/.changes/unreleased/Fixed-20230708-145543.yaml
@@ -1,0 +1,4 @@
+kind: Fixed
+body: Provide sentinel error exception only if 'error' is known. This may allow the
+  linter to operate in a broken environment.
+time: 2023-07-08T14:55:43.333839636-07:00


### PR DESCRIPTION
Don't explode if the 'error' type is not available.
If the error type is undefined, we just won't provide
the sentinel error exception.

This has a nice side effect of removing the `init()`
and bringing the coverage up to 100%.
